### PR TITLE
Set value to null when clearing a single select2

### DIFF
--- a/select2/select2.component.ts
+++ b/select2/select2.component.ts
@@ -49,7 +49,7 @@ export class LSelect2Component implements ControlValueAccessor {
     this._jqueryElement = $(this.selectControll.nativeElement);
     this.initSelect2();
 
-    this._jqueryElement.on('select2:select select2:unselect', () => {
+    this._jqueryElement.on('select2:select select2:unselect', (e) => {
       let data = this._jqueryElement.select2('data');
       for (let item of data) {
         delete item.element;
@@ -57,7 +57,7 @@ export class LSelect2Component implements ControlValueAccessor {
         delete item.selected;
       }
       if (!this.options.multiple) {
-        data = data[0];
+        data = (e.type == 'select2:unselect') ? null : data[0];
       }
       this._onChange(data);
     });


### PR DESCRIPTION
When clearing a Select2, the value was not properly updated on model, keeping the old value.

This patch fix this issue.